### PR TITLE
Paint rework

### DIFF
--- a/StratGAN/main.py
+++ b/StratGAN/main.py
@@ -45,8 +45,9 @@ flags.DEFINE_integer("paint_width", 1000, "The size of the paint images to produ
 flags.DEFINE_integer("paint_height", None, "The size of the paint images to produce. If None, value of paint_width/4 [None]")
 flags.DEFINE_integer("paint_overlap", 24, "The size of the overlap during painting [24]")
 flags.DEFINE_float("paint_overlap_thresh", 10.0, "The threshold L2 norm error for overlapped patch areas [10.0]")
-flags.DEFINE_string("paint_core_source", 'block', "Method for generating cores, if not recognized assume file name ['block']")
-flags.DEFINE_integer("paint_ncores", 0, "The number of cores to generate in the painting process, [0]")
+flags.DEFINE_boolean("paint_cores", False, "True for including cores in painting [False]")
+flags.DEFINE_string("paint_core_source", 'new', "Method for getting cores 'last' or 'new', if not recognized assume file name ['new']")
+flags.DEFINE_integer("paint_ncores", 2, "The number of cores to generate in the painting process, [0]")
 flags.DEFINE_float("paint_core_thresh", 2.0, "The threshold L2 norm error for overlapped core areas [2.0]")
 
 
@@ -93,6 +94,7 @@ config.paint_width = FLAGS.paint_width
 config.paint_height = FLAGS.paint_height
 config.paint_overlap = FLAGS.paint_overlap
 config.paint_overlap_thresh = FLAGS.paint_overlap_thresh
+config.paint_cores = FLAGS.paint_cores
 config.paint_core_source = FLAGS.paint_core_source
 config.paint_ncores = FLAGS.paint_ncores
 config.paint_core_thresh = FLAGS.paint_core_thresh

--- a/StratGAN/model.py
+++ b/StratGAN/model.py
@@ -448,31 +448,45 @@ class StratGAN(object):
         self.out_data_dir = os.path.join(self.config.out_dir, self.config.run_dir)
 
         # initialize the painter object
-        self.painter = painter.CanvasPainter(self, paint_label=self.config.paint_label, 
-                                                   paint_width=self.config.paint_width,
-                                                   paint_height=self.config.paint_height,
-                                                   paint_overlap=self.config.paint_overlap,
-                                                   paint_overlap_thresh=self.config.paint_overlap_thresh,
-                                                   paint_core_source=self.config.paint_core_source,
-                                                   paint_ncores=self.config.paint_ncores,
-                                                   paint_core_thresh=self.config.paint_core_thresh)
+        self.painter = painter.Painter(self, paint_label=self.config.paint_label, 
+                                             paint_width=self.config.paint_width,
+                                             paint_height=self.config.paint_height,
+                                             paint_overlap=self.config.paint_overlap,
+                                             paint_overlap_thresh=self.config.paint_overlap_thresh,
+                                             paint_core_thresh=self.config.paint_core_thresh)
+        print(self.painter.canvas)
 
         # sample now initialized
-        samp = plt.imshow(self.painter.canvas, cmap='gray')
-        plt.plot(self.painter.patch_xcoords, self.painter.patch_ycoords, marker='.', ls='none')
-        plt.savefig(os.path.join(self.paint_samp_dir, 'init.png'), bbox_inches='tight', dpi=300)
-        plt.close()
+        # samp = plt.imshow(self.painter.canvas, cmap='gray')
+        # plt.plot(self.painter.patch_xcoords, self.painter.patch_ycoords, marker='.', ls='none')
+        # plt.savefig(os.path.join(self.paint_samp_dir, 'init.png'), bbox_inches='tight', dpi=300)
+        # plt.close()
 
-        self.painter.fill_canvas()
 
-        fig, ax = plt.subplots()
-        ax.imshow(self.painter.canvas, cmap='gray')
-        plt.imshow(self.painter.core_canvas)
-        # plt.plot(self.painter.patch_xcoords, self.painter.patch_ycoords, marker='o', ls='none')
-        # fig.patch.set_visible(False)
-        # ax.axis('off')
-        plt.savefig(os.path.join(self.paint_samp_dir, 'final.png'), bbox_inches='tight', dpi=300)
-        plt.close()
+
+        # add cores to the painter object if option
+        # if self.config.paint_cores:
+        #     # add the cores
+        #     self.painter.add_cores(paint_core_source=self.config.paint_core_source,
+        #                            paint_ncores=self.config.paint_ncores)
+            
+        #     # determine which patch_xcoords are core coordinates 
+
+
+        #     # fill in patches at the core coordinates
+        #     self.painter.add_next_core_patch()
+
+        # # fill the remainder of the canvas
+        # self.painter.fill_canvas()
+
+        # fig, ax = plt.subplots()
+        # ax.imshow(self.painter.canvas, cmap='gray')
+        # plt.imshow(self.painter.core_canvas)
+        # # plt.plot(self.painter.patch_xcoords, self.painter.patch_ycoords, marker='o', ls='none')
+        # # fig.patch.set_visible(False)
+        # # ax.axis('off')
+        # plt.savefig(os.path.join(self.paint_samp_dir, 'final.png'), bbox_inches='tight', dpi=300)
+        # plt.close()
 
 
     def post_sampler(self, linear_interp=False, label_interp=False, random_realizations=False):

--- a/StratGAN/model.py
+++ b/StratGAN/model.py
@@ -454,7 +454,9 @@ class StratGAN(object):
                                              paint_overlap=self.config.paint_overlap,
                                              paint_overlap_thresh=self.config.paint_overlap_thresh,
                                              paint_core_thresh=self.config.paint_core_thresh)
-        print(self.painter.canvas.canvas)
+        # print(self.painter.canvas.canvas)
+
+        self.painter.canvas.fill_canvas()
 
         # sample now initialized
         # samp = plt.imshow(self.painter.canvas, cmap='gray')

--- a/StratGAN/model.py
+++ b/StratGAN/model.py
@@ -454,7 +454,7 @@ class StratGAN(object):
                                              paint_overlap=self.config.paint_overlap,
                                              paint_overlap_thresh=self.config.paint_overlap_thresh,
                                              paint_core_thresh=self.config.paint_core_thresh)
-        print(self.painter.canvas)
+        print(self.painter.canvas.canvas)
 
         # sample now initialized
         # samp = plt.imshow(self.painter.canvas, cmap='gray')

--- a/StratGAN/painter.py
+++ b/StratGAN/painter.py
@@ -58,16 +58,9 @@ class Painter(object):
         self.patch_height = self.patch_width = self.config.h_dim
         self.patch_size = self.patch_height * self.patch_width
 
-        # generate list of patch coordinates
-        self.patch_xcoords, self.patch_ycoords = self.calculate_patch_coords()
-        self.patch_count = self.patch_xcoords.size
-
-        self.canvas = [] # initialize as an empty list
-        for p in np.arange(self.patch_count):
-            init_next_patch = CanvasPatch(i=p, 
-                                          x_coord=self.patch_xcoords[p], y_coord=self.patch_ycoords[p],
-                                          width=self.patch_width, height=self.patch_height)
-            self.canvas.append(init_next_patch)
+        self.canvas = Canvas(canvas_width=self.paint_width, canvas_height=self.paint_height, 
+                             patch_width=self.patch_width, patch_height=self.patch_height, 
+                             patch_overlap=self.overlap)
 
         # self.canvas = np.ones((self.paint_height, self.paint_width))
         
@@ -158,17 +151,7 @@ class Painter(object):
         return core_val, core_loc
 
 
-    def calculate_patch_coords(self):
-        """
-        calculate location for patches to begin, currently ignores mod() patches
-        """
-        w = np.hstack((np.array([0]), np.arange(self.patch_width-self.overlap, self.paint_width-self.overlap, self.patch_width-self.overlap)[:-1]))
-        h = np.hstack((np.array([0]), np.arange(self.patch_height-self.overlap, self.paint_height-self.overlap, self.patch_height-self.overlap)[:-1]))
-        xm, ym = np.meshgrid(w, h)
-        x = xm.flatten()
-        y = ym.flatten()
-
-        return x, y
+    
 
 
     def add_next_patch(self):
@@ -535,9 +518,37 @@ class Canvas(object):
     It keeps track of which patches have been filled, edges, cores, etc. 
     """
     # all arguments are required because the defaults are handled with initial parser
-    def __init__(self, ):
-        pass
+    def __init__(self, canvas_width, canvas_height, patch_width, patch_height, 
+                 patch_overlap):
 
+        self.canvas_width = canvas_width
+        self.canvas_height = canvas_height
+        self.patch_width = patch_width
+        self.patch_height = patch_height
+        self.patch_overlap = patch_overlap
+
+        # generate list of patch coordinates
+        self.patch_xcoords, self.patch_ycoords = self.calculate_patch_coords()
+        self.patch_count = self.patch_xcoords.size
+
+        self.canvas = [] # initialize as an empty list
+        for p in np.arange(self.patch_count):
+            init_next_patch = CanvasPatch(i=p, 
+                                          patch_x_coord=self.patch_xcoords[p], patch_y_coord=self.patch_ycoords[p],
+                                          patch_width=self.patch_width, patch_height=self.patch_height,
+                                          patch_overlap=self.patch_overlap)
+            self.canvas.append(init_next_patch)
+
+    def calculate_patch_coords(self):
+        """
+        calculate location for patches to begin, currently ignores mod() patches
+        """
+        w = np.hstack((np.array([0]), np.arange(self.patch_width-self.patch_overlap, self.canvas_width-self.patch_overlap, self.patch_width-self.patch_overlap)[:-1]))
+        h = np.hstack((np.array([0]), np.arange(self.patch_height-self.patch_overlap, self.canvas_height-self.patch_overlap, self.patch_height-self.patch_overlap)[:-1]))
+        xm, ym = np.meshgrid(w, h)
+        x = xm.flatten()
+        y = ym.flatten()
+        return x, y
 
     def realize_as_image(self):
         pass
@@ -549,24 +560,35 @@ class CanvasPatch(object):
     Methods:
 
     """
-    def __init__(self, i, x_coord, y_coord, width, height, overlap):
+    def __init__(self, i, patch_x_coord, patch_y_coord, 
+                 patch_width, patch_height, patch_overlap):
         
         self.i = i
-        self.x_coord = x_coord
-        self.y_coord = y_coord
-        self.overlap = overlap
+        self.patch_x_coord = patch_x_coord
+        self.patch_y_coord = patch_y_coord
+        self.patch_height = patch_height
+        self.patch_width = patch_width
+        self.patch_overlap = patch_overlap
 
         self.is_filled = False
 
-        self.upper = np.zeros((self.overlap, self.width))
-        self.lower = 
-        self.left = 
-        self.right = 
-        self.center = 
+        # main patch attribute which holds information as 0 or 1
+        self.patch = np.zeros((self.patch_height, self.patch_width))
+
+        # preallocate and then reassign index parts
+        #   might stick this in submethod with options to handle partial patches
+        self.upper_idx = self.lower_idx = self.left_idx = \
+            self.right_idx = self.center_idx = np.full((self.patch_height, self.patch_width), False)
+        self.upper_idx[:self.patch_overlap, :] = True
+        # .... 
+        # ....
     
     def realize_as_image(self):
         self.compose_parts()
         pass
 
     def compose_parts(self):
+        pass
+
+    def fill_upper():
         pass


### PR DESCRIPTION
This branch is an attempt to rewrite the logic for how to paint out using the Efros-Freeman quilting. The current approach uses different object for each small patch. The thought is to just call a `Patch` to fill itself: it would check its neighbor patches for whether they have data, and then use the minimum cost boundary calculations to handle the quilting. This way you could go to core (or sand body) places first, and then quilt out from there (any arbitrary location).

This has proved challenging because it requires a __ton__ of config to be passed around, and because the cores run vertically, it's been kind of hard to get a sense for the correct alignment down a canvas...

May keep working on it, may try and think about another way to do things instead.